### PR TITLE
Use device name instead uuid when mounting storage disks

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'opscode-chef-openstack@googlegroups.com'
 license 'Apache 2.0'
 description 'Installs and configures Openstack Swift'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '11.0.4'
+version '11.1.0'
 
 recipe 'openstack-object-storage::account-server', 'Installs the swift account server'
 recipe 'openstack-object-storage::client', 'Install the swift client'

--- a/providers/mounts.rb
+++ b/providers/mounts.rb
@@ -42,7 +42,7 @@ action :ensure_exists do
     info['ip'] = @new_resource.ip
     info['format'] = @new_resource.format
     info['uuid'] = Mixlib::ShellOut.new("blkid /dev/#{device} -s UUID -o value").run_command.stdout.strip
-    info['mountpoint'] = info['uuid'].split('-').join('')
+    info['mountpoint'] = device
     info['mounted'] = Mixlib::ShellOut.new("mount | grep '#{path}/#{info['mountpoint']}\'").run_command.status
     info['size'] = Mixlib::ShellOut.new("sfdisk -s /dev/#{device}").run_command.stdout.to_i / 1024
 


### PR DESCRIPTION
Swift expects same mount point/device name as is in ring but cookbook mount point are constructed from UUID.
